### PR TITLE
Change fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,10 +9,7 @@
     />
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link
-      href="https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto+Slab|Roboto:300,400,500,700"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400&family=Permanent+Marker&display=swap" rel="stylesheet"> 
     <title>React Material Dashboard</title>
   </head>
   <body>

--- a/src/layout-components/Sidebar/components/SidebarNav.js
+++ b/src/layout-components/Sidebar/components/SidebarNav.js
@@ -48,7 +48,10 @@ const useStyles = makeStyles (theme => ({
 }));
 
 const CustomRouterLink = forwardRef ((props, ref) => (
-  <div ref={ref} style={{flexGrow: 1}}>
+  <div
+    ref={ref}
+    style={{flexGrow: 1}}
+  >
     <NavLink {...props} />
   </div>
 ));
@@ -59,9 +62,16 @@ const SidebarNav = props => {
   const classes = useStyles (openMini);
 
   return (
-    <List {...rest} className={clsx (classes.root, className)}>
+    <List
+      {...rest}
+      className={clsx (classes.root, className)}
+    >
       {pages.map (page => (
-        <ListItem className={classes.item} disableGutters key={page.title}>
+        <ListItem
+          className={classes.item}
+          disableGutters
+          key={page.title}
+        >
           <Button
             activeClassName={classes.active}
             className={classes.button}
@@ -69,14 +79,24 @@ const SidebarNav = props => {
             to={page.href}
           >
             <Grid>
-              <Grid container wrap="nowrap" direction="row">
+              <Grid
+                container
+                direction="row"
+                wrap="nowrap"
+              >
                 <Grid item>
-                <div className={classes.icon}>{page.icon}</div>
+                  <div className={classes.icon}>{page.icon}</div>
                 </Grid>
-                <Grid item zeroMinWidth>
-                <Typography color="textSecondary" noWrap>
-                  {openMini ? page.title : null}
-                </Typography>
+                <Grid
+                  item
+                  zeroMinWidth
+                >
+                  <Typography
+                    color="textSecondary"
+                    noWrap
+                  >
+                    {openMini ? page.title : null}
+                  </Typography>
                 </Grid>
                 
               </Grid>

--- a/src/layout-components/Sidebar/components/SidebarProfile.js
+++ b/src/layout-components/Sidebar/components/SidebarProfile.js
@@ -30,54 +30,65 @@ const SidebarProfile = ({className, openMini}) => {
     <div className={clsx (classes.root, className)}>
       <Grid>
 
-        <Grid container direction="row" justify="space-around" spacing={3}>
+        <Grid
+          container
+          direction="row"
+          justify="space-around"
+          spacing={3}
+        >
           <Grid item>
             {openMini
               ? <Grid
-                  container
-                  wrap="nowrap"
-                  spacing={3}
-                  style={{paddingRight: '70px'}}
-                >
-                  <Grid item>
-                    <Avatar
-                      alt="Person"
-                      className={classes.avatar}
-                      component={RouterLink}
-                      src="https://res.cloudinary.com/ddj5orpun/image/upload/c_scale,w_200/v1569892155/samples/landscapes/beach-boat.jpg"
-                      to="/Dashboard"
-                    />
-                  </Grid>
-                  <Grid item zeroMinWidth>
-                    <Typography
-                      className={classes.profileInfo}
-                      variant="body2"
-                      noWrap={true}
-                    >
-                      YOUR NAME
-                    </Typography>
-
-                    <Typography
-                      className={classes.profileInfo}
-                      variant="body2"
-                      noWrap={true}
-                    >
-                      YOUR BIO
-                    </Typography>
-                  </Grid>
-
+                container
+                spacing={3}
+                style={{paddingRight: '70px'}}
+                wrap="nowrap"
+              >
+                <Grid item>
+                  <Avatar
+                    alt="Person"
+                    className={classes.avatar}
+                    component={RouterLink}
+                    src="https://res.cloudinary.com/ddj5orpun/image/upload/c_scale,w_200/v1569892155/samples/landscapes/beach-boat.jpg"
+                    to="/Dashboard"
+                  />
                 </Grid>
-              : <Grid container spacing={3}>
-                  <Grid item>
-                    <Avatar
-                      alt="Person"
-                      className={classes.avatar}
-                      component={RouterLink}
-                      src="https://res.cloudinary.com/ddj5orpun/image/upload/c_scale,w_200/v1569892155/samples/landscapes/beach-boat.jpg"
-                      to="/Dashboard"
-                    />
-                  </Grid>
-                </Grid>}
+                <Grid
+                  item
+                  zeroMinWidth
+                >
+                  <Typography
+                    className={classes.profileInfo}
+                    noWrap
+                    variant="body2"
+                  >
+                      YOUR NAME
+                  </Typography>
+
+                  <Typography
+                    className={classes.profileInfo}
+                    noWrap
+                    variant="body2"
+                  >
+                      YOUR BIO
+                  </Typography>
+                </Grid>
+
+              </Grid>
+              : <Grid
+                container
+                spacing={3}
+              >
+                <Grid item>
+                  <Avatar
+                    alt="Person"
+                    className={classes.avatar}
+                    component={RouterLink}
+                    src="https://res.cloudinary.com/ddj5orpun/image/upload/c_scale,w_200/v1569892155/samples/landscapes/beach-boat.jpg"
+                    to="/Dashboard"
+                  />
+                </Grid>
+              </Grid>}
 
           </Grid>
 

--- a/src/layout-components/Sidebar/index.js
+++ b/src/layout-components/Sidebar/index.js
@@ -71,6 +71,7 @@ const useStyles = makeStyles (theme => ({
   },
   sideTitle: {
     color:'white',
+    fontFamily: 'Permanent Marker',
     transition: theme.transitions.create ('width', {
       easing: theme.transitions.easing.slow,
       duration: theme.transitions.duration.enteringScreen,

--- a/src/theme/typography.js
+++ b/src/theme/typography.js
@@ -1,8 +1,10 @@
 import palette from './palette';
 
 export default {
+  fontFamily: ['Roboto', 'sans-serif'],
   h1: {
-    color: palette.text.primary,
+    fontFamily: 'Permanent Marker',
+    color: palette.primary.main,
     fontWeight: 500,
     fontSize: '35px',
     letterSpacing: '-0.24px',

--- a/src/views/Dashboard/index.js
+++ b/src/views/Dashboard/index.js
@@ -15,9 +15,9 @@ function Dashboard (props) {
   return (
     <div className={classes.root}>
      
-          <Grid>
-            <Typography>THIS IS THE DASHBOARD</Typography>
-          </Grid>
+      <Grid>
+        <Typography variant="h1">THIS IS THE DASHBOARD</Typography>
+      </Grid>
 
     </div>
   );

--- a/src/views/Forums/index.js
+++ b/src/views/Forums/index.js
@@ -6,38 +6,38 @@ import {Grid, Typography} from '@material-ui/core'
 
 const Forums = (props) => {
 
-    const dispatch = useDispatch()
+  const dispatch = useDispatch()
 
-    useEffect (
-        () => {
-          dispatch (getPosts ());
-        },
-        [dispatch]
-      );
+  useEffect (
+    () => {
+      dispatch (getPosts ());
+    },
+    [dispatch]
+  );
 
       
   const {posts, isPostLoading} = useSelector (state => state.post);
 
-    return (
-        <Grid>
-            <Grid>
-            <Typography>
+  return (
+    <Grid>
+      <Grid>
+        <Typography variant="h1">
                 This is the forums page.
-            </Typography>
-            </Grid>
-            <Grid>
-            <Typography>
+        </Typography>
+      </Grid>
+      <Grid>
+        <Typography>
                 # of posts: {posts.length}
-            </Typography>
-            <Typography>
+        </Typography>
+        <Typography>
                 Todo: expand into a fully functional message board
-            </Typography>
+        </Typography>
 
-            </Grid>
+      </Grid>
             
-        </Grid>
+    </Grid>
          
-    )
+  )
 }
 
 Forums.propTypes = {

--- a/src/views/Landing/index.js
+++ b/src/views/Landing/index.js
@@ -15,9 +15,9 @@ function Landing (props) {
   return (
     <div className={classes.root}>
      
-          <Grid>
-            <Typography>THIS IS THE Landing</Typography>
-          </Grid>
+      <Grid>
+        <Typography variant="h1">THIS IS THE Landing</Typography>
+      </Grid>
 
     </div>
   );


### PR DESCRIPTION
This pull request changes the fonts of the app from Roboto to "Open Sans" for body text and "Permanent Marker" for h1/heading text. 

Specifically, I swapped out the google font links in the index.html file, added a font family property of "Open Sans' in the theme's typography, added a font family of "Permanent Marker" in the h1 property of the theme's typography, changed h1's color to palette.primary.main, changed the side title's font family to "Permanent Marker", and I set the variant on the heading typography in each view to h1 in order to reflect the changes temporarily until I add the heading component.