### PR TITLE
Remove textAlign property from h1

### DIFF
--- a/src/theme/typography.js
+++ b/src/theme/typography.js
@@ -9,7 +9,6 @@ export default {
     fontSize: '35px',
     letterSpacing: '-0.24px',
     lineHeight: '40px',
-    textAlign: 'center',
     margin: '3rem 0'
   },
   h2: {


### PR DESCRIPTION
Just removed the textAlign property from the h1 in the typography theme.